### PR TITLE
DEVOPS-102: updated ecs task to allow the service name to be passed in

### DIFF
--- a/ansible/collections/bento/common/roles/ecs/tasks/main.yml
+++ b/ansible/collections/bento/common/roles/ecs/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: create task definition for {{ project_name }}-{{ container_name }}
+- name: create task definition for {{ service_name }}
   community.aws.ecs_taskdefinition:
     containers:
       - name: sumologic-firelens
@@ -9,7 +9,7 @@
           type: fluentbit
           options:
             enable-ecs-log-metadata: "true"
-      - name: "{{ project_name }}-{{ container_name }}-newrelic-infra"
+      - name: newrelic-infra
         essential: true
         image: "newrelic/nri-ecs:1.9.2"
         environment:
@@ -18,7 +18,7 @@
           - name: NRIA_IS_FORWARD_ONLY
             value: "true"
           - name: NEW_RELIC_APP_NAME
-            value: "{{ project_name }}-{{ tier }}-{{ container_name }}"
+            value: "{{ service_name }}"
           - name: NEW_RELIC_DISTRIBUTED_TRACING_ENABLED
             value: "true"
           - name: NEW_RELIC_HOST
@@ -54,7 +54,7 @@
     network_mode: awsvpc
     execution_role_arn: "arn:aws:iam::{{ account }}:role/{{ execution_role }}"
     task_role_arn: "arn:aws:iam::{{ account }}:role/{{ task_role }}"
-    family: "{{ project_name }}-{{ tier }}-{{ container_name }}"
+    family: "{{ service_name }}"
     memory: "{{ container_memory }}"
     cpu: "{{ container_cpu }}"
     state: present
@@ -67,7 +67,7 @@
 ############################################################################################################################
 - name: query task definition - {{ container_name }}
   ecs_taskdefinition_info:
-    task_definition: "{{ project_name }}-{{ tier }}-{{ container_name }}"
+    task_definition: "{{ service_name }}"
     region: "{{ region }}"
   register: task
 
@@ -77,7 +77,7 @@
 - name: query {{ container_name }} service
   ecs_service_info:
     cluster: "{{ ecs_cluster_name }}"
-    service: "{{ project_name }}-{{ tier }}-{{ container_name }}"
+    service: "{{ service_name }}"
     details: true
     region: "{{ region }}"
   register: service
@@ -95,7 +95,7 @@
 - name: update {{ container_name }} service
   ecs_service:
     state: present
-    name: "{{ project_name }}-{{ tier }}-{{ container_name }}"
+    name: "{{ service_name }}"
     cluster: "{{ ecs_cluster_name }}"
     task_definition: "{{ task_name }}:{{ task_revision }}"
     role: "{{ role_arn }}"

--- a/terraform/modules/aurora/README.md
+++ b/terraform/modules/aurora/README.md
@@ -35,7 +35,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Enable to allow major engine version upgrades when changing engine versions | `bool` | `false` | no |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Enable to allow major engine version upgrades when changing engine versions | `bool` | `true` | no |
 | <a name="input_allowed_ip_blocks"></a> [allowed\_ip\_blocks](#input\_allowed\_ip\_blocks) | allowed ip block for the rds ingress | `list(string)` | `[]` | no |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | list of availability zones | `list(any)` | `[]` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | number of days to keep backup | `number` | `35` | no |


### PR DESCRIPTION
The updated version of this code accepts a variable "service_name" and no longer defines this based only on the project/tier/container being deployed. This will require an update to the playbook calling this script to define the service_name variable