### PR TITLE
updated ecr module to allow passing in naming convention

### DIFF
--- a/terraform/modules/ecr/README.md
+++ b/terraform/modules/ecr/README.md
@@ -31,13 +31,13 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_ecr_replication"></a> [allow\_ecr\_replication](#input\_allow\_ecr\_replication) | allow ecr replication | `bool` | `false` | no |
-| <a name="input_create_env_specific_repo"></a> [create\_env\_specific\_repo](#input\_create\_env\_specific\_repo) | choose to create environment specific repo. Example bento-dev-frontend | `bool` | `true` | no |
+| <a name="input_resource_prefix"></a> [create\_env\_specific\_repo](#input\_resource\_prefix) | the prefix to add when creating resources | `string` | n/a | yes |
 | <a name="input_ecr_repo_names"></a> [ecr\_repo\_names](#input\_ecr\_repo\_names) | list of repo names | `list(string)` | n/a | yes |
 | <a name="input_enable_ecr_replication"></a> [enable\_ecr\_replication](#input\_enable\_ecr\_replication) | enable ecr replication | `bool` | `false` | no |
 | <a name="input_env"></a> [env](#input\_env) | name of the environment to provision | `string` | n/a | yes |
 | <a name="input_replication_destination_registry_id"></a> [replication\_destination\_registry\_id](#input\_replication\_destination\_registry\_id) | registry id for destination image | `string` | `""` | no |
 | <a name="input_replication_source_registry_id"></a> [replication\_source\_registry\_id](#input\_replication\_source\_registry\_id) | registry id for source image | `string` | `""` | no |
-| <a name="input_stack_name"></a> [stack\_name](#input\_stack\_name) | name of the project | `string` | n/a | yes |
+| <a name="input_project"></a> [stack\_name](#input\_stack\_name) | name of the project | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | tags to associate with this instance | `map(string)` | n/a | yes |
 
 ## Outputs

--- a/terraform/modules/ecr/locals.tf
+++ b/terraform/modules/ecr/locals.tf
@@ -1,4 +1,3 @@
 locals {
   account_arn = format("arn:aws:iam::%s:root", data.aws_caller_identity.current.account_id)
-  ecr_repo_prefix = var.create_env_specific_repo ? "${var.stack_name}-${var.env}" : var.stack_name
 }

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,6 +1,6 @@
 resource "aws_ecr_repository" "ecr" {
   for_each             = toset(var.ecr_repo_names)
-  name                 = "${local.ecr_repo_prefix}-${each.key}"
+  name                 = "${var.resource_prefix}-${each.key}"
   image_tag_mutability = "MUTABLE"
   tags = merge(
     {
@@ -23,14 +23,14 @@ resource "aws_ecr_lifecycle_policy" "ecr_life_cycle" {
   policy = jsonencode({
     rules = [{
       rulePriority = 1
-      description  = "keep last 20 images"
+      description  = "keep last ${var.max_images_to_keep} images"
       action = {
         type = "expire"
       }
       selection = {
         tagStatus   = "any"
         countType   = "imageCountMoreThan"
-        countNumber = 15
+        countNumber = var.max_images_to_keep
       }
     }]
   })

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -1,3 +1,8 @@
+variable "resource_prefix" {
+  description = "the prefix to add when creating resources"
+  type        = string
+}
+
 variable "tags" {
   description = "tags to associate with this instance"
   type        = map(string)
@@ -8,8 +13,8 @@ variable "ecr_repo_names" {
   type        = list(string)
 }
 
-variable "stack_name" {
-  description = "name of the project"
+variable "project" {
+  description = "the name of the project"
   type        = string
 }
 
@@ -18,26 +23,32 @@ variable "env" {
   type        = string
 }
 
-variable "create_env_specific_repo" {
-  description = "choose to create environment specific repo. Example bento-dev-frontend"
-  type = bool
-  default = true
+# Lifecycle Policy Configuration
+variable "max_images_to_keep" {
+  description = "the maximum number of images to keep in the repository"
+  type = number
+  default = 20
 }
+
+# Replication
 variable "replication_destination_registry_id" {
   type = string
   description = "registry id for destination image"
   default = ""
 }
+
 variable "replication_source_registry_id" {
   type = string
   description = "registry id for source image"
   default = ""
 }
+
 variable "enable_ecr_replication" {
   description = "enable ecr replication"
   type = bool
   default = false
 }
+
 variable "allow_ecr_replication" {
   description = "allow ecr replication"
   type = bool


### PR DESCRIPTION
changes included in this update include:

1. added the required variable resource_prefix to allow setting a naming convention outside of the module and passing this in. resources will all be named using this prefix - for ECR this means the repository names will be "${var.resource_prefix}-<service name>"
2. removed hardcoded values (number of images to keep in the repo for the lifecycle policy) and set them using default values for variables