### PR TITLE
updated the ECS module policies for ecr

### DIFF
--- a/terraform/modules/ecs/data.tf
+++ b/terraform/modules/ecs/data.tf
@@ -61,16 +61,12 @@ data "aws_iam_policy_document" "task_execution_ecr" {
       "ecr:BatchGetImage",
       "ecr:GetDownloadUrlForLayer",
       "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:CompleteLayerUpload",
       "ecr:DescribeRepositories",
-      "ecr:GetLifecyclePolicy",
-      "ecr:GetRepositoryPolicy",
-      "ecr:InitiateLayerUpload",
       "ecr:ListTagsForResource",
-      "ecr:UploadLayerPart",
+      "ecr:DescribeImages",
+      "ecr:ListImages"
     ]
-    resources = ["arn:aws:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"]
+    resources = var.ecr_repo_arns
   }
   statement {
     effect = "Allow"

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -114,5 +114,9 @@ variable "create_neo4j_db" {
   type = bool
   default = false
   description = "choose to add neo4j container or not"
+}
 
+variable "ecr_repo_arns" {
+  type = list(string)
+  description = "provide a list of arns for ecr repos to allow access to"
 }


### PR DESCRIPTION
@Charlo237 - I updated the ECS module to parameterize the ECR repositories that apply to the ECS task execution role. Please have a look and ask questions if they come to mind. 

At the ICDC project level, I'd recommend the following:
1. Create a new variable called `ecr_repository_arns`, which would be of type `list`. 
2. Update your TFVars files with the ARNs for the repositories - that should also be formatted as a list, and contain the ARNs of all central ECR repositories that ICDC needs to access.
3. Update your ecs.tf file to include the new module variable, and pass the ICDC variable containing the list of ECR ARNs to the module variable. 