### PR TITLE
resolving issues related to instance parameters

### DIFF
--- a/terraform/modules/neptune-cluster/main.tf
+++ b/terraform/modules/neptune-cluster/main.tf
@@ -34,7 +34,7 @@ resource "aws_neptune_cluster" "this" {
 }
 
 module "cluster_parameters" {
-  count = var.enable_serverless ? 0 : 1
+  count  = var.enable_serverless ? 0 : 1
   source = "git::https://github.com/CBIIT/datacommons-devops.git//terraform/modules/neptune-cluster-parameter-group?ref=Neptune"
 
   resource_prefix  = var.resource_prefix
@@ -42,11 +42,12 @@ module "cluster_parameters" {
 }
 
 module "instance_parameters" {
+  count  = var.enable_serverless ? 0 : 1
   source = "git::https://github.com/CBIIT/datacommons-devops.git//terraform/modules/neptune-instance-parameter-group?ref=Neptune"
 
   resource_prefix = var.resource_prefix
-  enable_caching = var.enable_serverless ? false : var.enable_caching
-  query_timeout  = var.query_timeout
+  enable_caching  = var.enable_serverless ? false : var.enable_caching
+  query_timeout   = var.query_timeout
 }
 
 module "neptune_instance" {
@@ -57,7 +58,7 @@ module "neptune_instance" {
   engine_version               = var.engine_version
   instance_class               = var.enable_serverless ? "db.serverless" : var.instance_class
   neptune_subnet_group_name    = aws_neptune_subnet_group.this.name
-  neptune_parameter_group_name = var.enable_serverless ? "default.neptune1.2" : module.instance_parameters.name
+  neptune_parameter_group_name = var.enable_serverless ? "default.neptune1.2" : module.instance_parameters[0].name
   port                         = var.port
 }
 


### PR DESCRIPTION
Enacted a change that would conditionally create Neptune Instance Parameter resource if the Neptune cluster is anything but Serverless. When `var.enable_serverless` = `true`, then we do not need to create a parameter group. 