### PR TITLE
Fixed bug related to OpenSearch Cluster Config Instance Count parameter

### DIFF
--- a/terraform/modules/opensearch/main.tf
+++ b/terraform/modules/opensearch/main.tf
@@ -6,7 +6,7 @@ resource "aws_opensearch_domain" "this" {
 
   cluster_config {
     instance_type  = local.custom_instance_type
-    instance_count = var.zone_awareness_enabled ? local.custom_instance_count : (local.custom_instance_count * 2)
+    instance_count = var.zone_awareness_enabled ? (local.custom_instance_count * 2) : local.custom_instance_count
 
     zone_awareness_enabled = var.zone_awareness_enabled
 


### PR DESCRIPTION
## Updates to the OpenSearch Module
Fixed a bug in the main.tf file that produced configurations with two (or more) data node instance counts by default, even when the intention was to have only one data node.

This change fixes the `instance_count` parameter inside the `cluster_config` block, which uses a conditional to create OpenSearch node counts based on the multi-az configuration specification.