### PR TITLE
feat: add CRDC Data Model Navigator monitoring (DATATEAM-283)

### DIFF
--- a/monitoring/FNL-Monitoring-List.csv
+++ b/monitoring/FNL-Monitoring-List.csv
@@ -1328,3 +1328,5 @@ CCDI Datasharing,Datasharing Hub,CCDI,Dev,Portal,https://datasharing-dev.cancer.
 CCDI Datasharing,Datasharing Hub,CCDI,QA,Portal,https://datasharing-qa.cancer.gov/post/Data/cancer-data-resources/,,,TRUE,C09LV13BR7F,,,
 CCDI Datasharing,Datasharing Hub,CCDI,Stage,Portal,https://datasharing-stage.cancer.gov/post/Data/cancer-data-resources/,,,TRUE,C09LV13BR7F,,,
 CCDI Datasharing,Datasharing Hub,CCDI,Prod,Portal,https://datasharing.cancer.gov/post/Data/cancer-data-resources/,,,FALSE,C09MSJJRD16,,,
+CRDC Data Model Navigator,dmn,CRDC,Dev,Portal,https://dp2mdhy99qjlv.cloudfront.net/,,,FALSE,C08UECW5R98,,,
+CRDC Data Model Navigator,dmn,CRDC,Prod,Portal,https://d1bxc1yd643e0n.cloudfront.net/,,,FALSE,C08UECW5R98,,,


### PR DESCRIPTION
## Summary
- Adds **CRDC Data Model Navigator** (`dmn`) Dev and Prod monitoring entries to `monitoring/FNL-Monitoring-List.csv`
- Alerts routed to `#data-model-navigator` Slack channel (`C08UECW5R98`)
- Uses public CloudFront URLs (no private location required)

## Changes
| Tier | URL | Private Location | Slack Channel |
|---|---|---|---|
| Dev | https://dp2mdhy99qjlv.cloudfront.net/ | FALSE | #data-model-navigator |
| Prod | https://d1bxc1yd643e0n.cloudfront.net/ | FALSE | #data-model-navigator |

> Note: Only Dev and Prod environments exist for this project (no QA/Stage). CloudFront URLs confirmed live and correct per CTDC-1850 (closed).

## Jira
Closes DATATEAM-283